### PR TITLE
Tec 2899 bluebird error

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -871,17 +871,23 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
       }
     };
 
+    console.log('PROMISE!');
+    console.log(Promise);
+    console.log(Promise.version);
+
     const delayUpdate = () => {
       scripts
         .updateDelaySet(this, Date.now())
         .then(nextTimestamp => {
+          let nextPromise = null;
           if (nextTimestamp) {
             nextTimestamp /= 4096;
             const now = Date.now();
             const delay = nextTimestamp > now ? nextTimestamp - now : 0;
-            update(delay);
+            nextPromise = update(delay);
           }
           this.delayedTimestamp = nextTimestamp || Number.MAX_VALUE;
+          return nextPromise;
         })
         .catch(err => {
           this.emit('error', err, 'Error updating the delay timer');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -879,15 +879,14 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
       scripts
         .updateDelaySet(this, Date.now())
         .then(nextTimestamp => {
-          let nextPromise = null;
           if (nextTimestamp) {
             nextTimestamp /= 4096;
             const now = Date.now();
             const delay = nextTimestamp > now ? nextTimestamp - now : 0;
-            nextPromise = update(delay);
+            update(delay);
           }
           this.delayedTimestamp = nextTimestamp || Number.MAX_VALUE;
-          return nextPromise;
+          return null;
         })
         .catch(err => {
           this.emit('error', err, 'Error updating the delay timer');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -867,16 +867,13 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
         delay = delay < MAX_TIMEOUT_MS ? delay : MAX_TIMEOUT_MS;
         this.delayTimer = setTimeout(delayUpdate, delay);
       } else {
-        return delayUpdate();
+        delayUpdate();
       }
+      return null;
     };
 
-    console.log('PROMISE!');
-    console.log(Promise);
-    console.log(Promise.version);
-
     const delayUpdate = () => {
-      scripts
+      return scripts
         .updateDelaySet(this, Date.now())
         .then(nextTimestamp => {
           if (nextTimestamp) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -42,7 +42,7 @@ const commands = require('./commands/');
     job -> wait -> active
        \     ^            \
         v    |             -- > failed
-        delayed 
+        delayed
 */
 
 /**
@@ -867,7 +867,7 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
         delay = delay < MAX_TIMEOUT_MS ? delay : MAX_TIMEOUT_MS;
         this.delayTimer = setTimeout(delayUpdate, delay);
       } else {
-        delayUpdate();
+        return delayUpdate();
       }
     };
 


### PR DESCRIPTION
Even though bull isn't using bluebird anymore, for some reason we're getting bluebird warnings about the way promises are being handled in the internals of bull. I think it's probably from another package that's crosscontaminating the global namespace or something, but I dont want to figure it out right now.

So instead, I fixed the code causing the warnings by always returning null from the promise handlers, which allegedly signals to bluebird that it doesn't need to warn us